### PR TITLE
Encerrar issues abertas por inatividade

### DIFF
--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -1,0 +1,16 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Esta vaga encontra-se há um bom tempo sem novas interações. Se ainda estiver aberta, faça um comentário, caso contrario, a fecharemos automaticamente em 5 dias.'
+        days-before-stale: 60
+        days-before-close: 5
+        ascending: true


### PR DESCRIPTION
Cria uma action para fechar as issues que estão abertas a mais de 60 dias sem atualizações.
Isso ajuda a manter as vagas ativas e atualizadas.
Existem issues abertas desde Dezembro de 2018 como #10 